### PR TITLE
fixed column display issue

### DIFF
--- a/src/components/dataTable/DataTable.tsx
+++ b/src/components/dataTable/DataTable.tsx
@@ -91,8 +91,6 @@ const DataTable: React.FC<TableProps> = ({ data, columns }) => {
         download: false,
         print: false,
         search: false,
-        fixedHeader: true,
-        viewColumns: true,
     };
 
     return (

--- a/src/components/dataTable/DataTableColumns.tsx
+++ b/src/components/dataTable/DataTableColumns.tsx
@@ -31,7 +31,6 @@ export interface Column {
     label: string;
     options: {
         customBodyRender: (val: any) => JSX.Element;
-        display?: boolean;
     };
 }
 
@@ -60,8 +59,7 @@ export const columns: Column[] = [
         name: "sourceFolder",
         label: "Source Folder",
         options: {
-            customBodyRender: renderCell,
-            display: false
+            customBodyRender: renderCell
         }
     },
     {
@@ -96,8 +94,7 @@ export const columns: Column[] = [
         name: "metadata",
         label: "Metadata",
         options: {
-            customBodyRender: renderCell,
-            display: false
+            customBodyRender: renderCell
         }
     },
     {
@@ -111,16 +108,14 @@ export const columns: Column[] = [
         name: "ownerGroup",
         label: "Group",
         options: {
-            customBodyRender: renderCell,
-            display: false
+            customBodyRender: renderCell
         }
     },
     {
         name: "dataStatus",
         label: "Status",
         options: {
-            customBodyRender: renderCell,
-            display: false
+            customBodyRender: renderCell
         }
     },
 ];


### PR DESCRIPTION
- An issue occured with the columns panel showing added columns when panel was open but disappearing again when panel closed. 
- The columns having the 'display: false' value on 'options' would still disappear when resize of table was made, as it causes the table to re-render. The easy solution, but not the ideal one, is to have all columns be displayed by default and then let user decide to hide them if desired. Due to not having more time to look into it, I opted for that solution.